### PR TITLE
Fix EMA ignore set

### DIFF
--- a/naturalspeech2_pytorch/naturalspeech2_pytorch.py
+++ b/naturalspeech2_pytorch/naturalspeech2_pytorch.py
@@ -898,7 +898,7 @@ class Trainer(object):
                 diffusion_model,
                 beta = ema_decay,
                 update_every = ema_update_every,
-                ignore_startswith_names = set('codec.')
+                ignore_startswith_names = set(['codec.'])
             ).to(self.device)
 
             diffusion_model.codec = codec


### PR DESCRIPTION
Very minor bugfix. EMA intermediate results were almost pure noise and it was probably due to the ignore set being wrong - the `set(str)` constructor created a set with each char of the string instead of creating a set with a single string.