### PR TITLE
[minor changes] typo in ns2.py and aligner.py

### DIFF
--- a/naturalspeech2_pytorch/aligner.py
+++ b/naturalspeech2_pytorch/aligner.py
@@ -207,6 +207,7 @@ if __name__ == '__main__':
 
     x = torch.randn(batch_size, 512, seq_len_x)
     y = torch.randn(batch_size, seq_len_y, feature_dim)
+    y = y.transpose(1,2) #dim-1 is the channels for conv
     
     # Create masks
     x_mask = torch.ones(batch_size, 1, seq_len_x)

--- a/naturalspeech2_pytorch/naturalspeech2_pytorch.py
+++ b/naturalspeech2_pytorch/naturalspeech2_pytorch.py
@@ -1523,11 +1523,11 @@ class NaturalSpeech2(nn.Module):
 
             # alignment
 
-            aln_hard, aln_soft, aln_log, aln_mas = self.aligner(phoneme_enc, text_mask, mel, mel_mask)
+            aln_hard, aln_soft, aln_log, aln_mask = self.aligner(phoneme_enc, text_mask, mel, mel_mask)
             duration_pred, pitch_pred = self.duration_pitch(phoneme_enc, prompt_enc)
 
             pitch = average_over_durations(pitch, aln_hard)
-            cond = self.expand_encodings(rearrange(phoneme_enc, 'b n d -> b d n'), rearrange(aln_mas, 'b n c -> b 1 n c'), pitch)
+            cond = self.expand_encodings(rearrange(phoneme_enc, 'b n d -> b d n'), rearrange(aln_mask, 'b n c -> b 1 n c'), pitch)
 
             # pitch and duration loss
 


### PR DESCRIPTION
- [minor] Typo mas -> mask (it confused me with MAS = monotonic alignment search ; which is a type of alignment in TTS; but that is the aln_hard in this case and aln_mas is the mask)
- updated the minimal working example in aligner